### PR TITLE
Update dependency to iOS 13.1.0 release

### DIFF
--- a/PSPDFKit.dotnet.iOS.Model/ApiDefinition.cs
+++ b/PSPDFKit.dotnet.iOS.Model/ApiDefinition.cs
@@ -6612,6 +6612,9 @@ namespace PSPDFKit.Model {
 
 		[Export ("loadAllAnnotations")]
 		void LoadAllAnnotations ();
+
+		[Export ("ignorePageRotation")]
+		bool ignorePageRotation { get; set; }
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -6637,6 +6640,9 @@ namespace PSPDFKit.Model {
 
 		[Export ("dataProvider")]
 		IPSPDFDataProviding DataProvider { get; }
+
+		[Export ("ignorePageRotation")]
+		bool ignorePageRotation { get; set; }
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -6644,6 +6650,9 @@ namespace PSPDFKit.Model {
 
 		[Export ("writeAnnotations:toDataSink:documentProvider:error:")]
 		bool WriteAnnotations (PSPDFAnnotation [] annotations, IPSPDFDataSink dataSink, PSPDFDocumentProvider documentProvider, [NullAllowed] out NSError error);
+
+		[Export ("ignorePageRotation")]
+		bool ignorePageRotation { get; set; }
 	}
 
 	[BaseType (typeof (NSFormatter))]

--- a/PSPDFKit.dotnet.iOS.Model/ApiDefinition.cs
+++ b/PSPDFKit.dotnet.iOS.Model/ApiDefinition.cs
@@ -6614,7 +6614,7 @@ namespace PSPDFKit.Model {
 		void LoadAllAnnotations ();
 
 		[Export ("ignorePageRotation")]
-		bool ignorePageRotation { get; set; }
+		bool IgnorePageRotation { get; set; }
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -6642,7 +6642,7 @@ namespace PSPDFKit.Model {
 		IPSPDFDataProviding DataProvider { get; }
 
 		[Export ("ignorePageRotation")]
-		bool ignorePageRotation { get; set; }
+		bool IgnorePageRotation { get; set; }
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -6652,7 +6652,7 @@ namespace PSPDFKit.Model {
 		bool WriteAnnotations (PSPDFAnnotation [] annotations, IPSPDFDataSink dataSink, PSPDFDocumentProvider documentProvider, [NullAllowed] out NSError error);
 
 		[Export ("ignorePageRotation")]
-		bool ignorePageRotation { get; set; }
+		bool IgnorePageRotation { get; set; }
 	}
 
 	[BaseType (typeof (NSFormatter))]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PSPDFKit.NET (iOS)
 
-- .NET for iOS, MacCatalyst Bindings for PSPDFKit version 13.0.1
+- .NET for iOS, MacCatalyst Bindings for PSPDFKit version 13.1.0
 
 #### PSPDFKit
 
@@ -87,7 +87,7 @@ Also you do need to set your **license key** early on in your `AppDelegate`, bef
 ```csharp
 public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
 {
-	PSPDFKitGlobal.SetLicenseKey (null, null);
+	PSPDFKitGlobal.SetLicenseKey (null);
 	// ...
 }
 ```

--- a/build.cake
+++ b/build.cake
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
-var IOSVERSION = Argument("iosversion", "13.0.1");
+var IOSVERSION = Argument("iosversion", "13.1.0");
 var IOS_SERVICERELEASE_VERSION = "0"; // This is combined with the IOSVERSION variable for the NuGet Package version
 
 var target = Argument ("target", "Default");


### PR DESCRIPTION
Update the project dependency to iOS 13.1.0 and expose new property on existing interfaces.