### PR TITLE
Changes to update PSPDFKit iOS framework dependency to 13.8.0 (HYB-496)

### DIFF
--- a/PSPDFKit.dotnet.iOS.Model/ApiDefinition.cs
+++ b/PSPDFKit.dotnet.iOS.Model/ApiDefinition.cs
@@ -2959,6 +2959,9 @@ namespace PSPDFKit.Model {
 		[Export ("defaultMeasurementValueConfiguration")]
 		[NullAllowed]
 		PSPDFMeasurementValueConfiguration DefaultMeasurementValueConfiguration { get; set; }
+
+		[Export ("addAnnotationFromInstantJSON:attachmentDataProvider:error:")]
+		PSPDFAnnotation AddAnnotation (NSData instantJSON, [NullAllowed] IPSPDFDataProviding attachmentDataProvider, [NullAllowed] out NSError error);
 	}
 
 	interface IPSPDFDocumentProviderDelegate { }

--- a/PSPDFKit.dotnet.iOS.UI/ApiDefinition.cs
+++ b/PSPDFKit.dotnet.iOS.UI/ApiDefinition.cs
@@ -2710,6 +2710,9 @@ namespace PSPDFKit.UI {
 		[Export ("subtitleForAnnotationsOptions:sharingConfiguration:")]
 		[return: NullAllowed]
 		string GetSubtitleForAnnotationsOptions (PSPDFDocumentSharingAnnotationOptions option, PSPDFDocumentSharingConfiguration sharingConfiguration);
+
+		[Export ("title")]
+		string Title { get; set; }
 	}
 
 	interface IPSPDFDocumentViewControllerDelegate { }
@@ -7854,8 +7857,12 @@ namespace PSPDFKit.UI {
 		[Export ("pdfViewController:willScheduleRenderTaskForPageView:")]
 		void WillScheduleRenderTask (PSPDFViewController pdfController, PSPDFPageView pageView);
 
+		[Obsolete ("Deprecated in PSPDFKit 13 for iOS. Use the similar method with an error parameter instead.")]
 		[Export ("pdfViewController:didFinishRenderTaskForPageView:")]
 		void DidFinishRenderTask (PSPDFViewController pdfController, PSPDFPageView pageView);
+
+		[Export ("pdfViewController:didFinishRenderTaskForPageView:error:")]
+		void DidFinishRenderTask (PSPDFViewController pdfController, PSPDFPageView pageView, [NullAllowed] NSError error);
 
 		[Export ("pdfViewController:didUpdateContentImageForPageView:isPlaceholder:")]
 		void DidUpdateContentImage (PSPDFViewController pdfController, PSPDFPageView pageView, bool placeholder);
@@ -7954,7 +7961,7 @@ namespace PSPDFKit.UI {
 
 		[Export ("pdfViewController:menuForImage:onPageView:appearance:suggestedMenu:")]
 		UIMenu GetMenuForImage (PSPDFViewController sender, PSPDFImageInfo image, PSPDFPageView pageView, PSPDFEditMenuAppearance appearance, UIMenu suggestedMenu);
-
+		
 		[Obsolete ("Use 'pdfViewController(_:menuForAnnotations:onPageView:appearance:suggestedMenu:)' or 'pdfViewController(_:menuForCreatingAnnotationAt:onPageView:appearance:suggestedMenu:)' instead.")]
 		[Export ("pdfViewController:shouldShowMenuItems:atSuggestedTargetRect:forAnnotations:inRect:onPageView:")]
 		PSPDFMenuItem [] ShouldShowMenuItemsForAnnotations (PSPDFViewController pdfController, PSPDFMenuItem [] menuItems, CGRect rect, [NullAllowed] PSPDFAnnotation [] annotations, CGRect annotationRect, PSPDFPageView pageView);

--- a/PSPDFKit.dotnet.iOS.UI/ApiEnhancements.cs
+++ b/PSPDFKit.dotnet.iOS.UI/ApiEnhancements.cs
@@ -30,7 +30,7 @@ namespace PSPDFKit.UI {
 	public partial class PSPDFAnnotationTableViewController {
 
 		public PSPDFAnnotationStringUI [] VisibleAnnotationTypes {
-			get => WeakVisibleAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray ();
+			get => WeakVisibleAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFAnnotationStringUI>();
 			set => WeakVisibleAnnotationTypes = value == null ? null : new NSSet<NSString> (value.Select (x => x.GetConstant ())?.ToArray ());
 		}
 
@@ -43,7 +43,7 @@ namespace PSPDFKit.UI {
 	public partial class PSPDFAnnotationTableViewController {
 
 		public PSPDFAnnotationStringUI [] EditableAnnotationTypesUI {
-			get => WeakEditableAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray ();
+			get => WeakEditableAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFAnnotationStringUI>();
 			set => WeakEditableAnnotationTypes = value == null ? null : new NSSet<NSString> (value.Select (x => x.GetConstant ())?.ToArray ());
 		}
 	}
@@ -51,7 +51,7 @@ namespace PSPDFKit.UI {
 	public partial class PSPDFAnnotationToolbar {
 
 		public PSPDFAnnotationStringUI [] EditableAnnotationTypes {
-			get => WeakEditableAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray ();
+			get => WeakEditableAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFAnnotationStringUI>();
 			set => WeakEditableAnnotationTypes = value == null ? null : new NSSet<NSString> (value.Select (x => x.GetConstant ())?.ToArray ());
 		}
 	}
@@ -59,7 +59,7 @@ namespace PSPDFKit.UI {
 	public partial class PSPDFConfigurationBuilder {
 
 		public PSPDFAnnotationStringUI [] EditableAnnotationTypes {
-			get => WeakEditableAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray ();
+			get => WeakEditableAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFAnnotationStringUI>();
 			set => WeakEditableAnnotationTypes = value == null ? null : new NSSet<NSString> (value.Select (x => x.GetConstant ())?.ToArray ());
 		}
 	}
@@ -67,7 +67,7 @@ namespace PSPDFKit.UI {
 	public partial class PSPDFConfiguration {
 
 		public PSPDFAnnotationStringUI [] EditableAnnotationTypes {
-			get => WeakEditableAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray ();
+			get => WeakEditableAnnotationTypes?.ToArray ()?.Select (x => PSPDFAnnotationStringUIExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFAnnotationStringUI>();
 		}
 	}
 
@@ -99,7 +99,7 @@ namespace PSPDFKit.UI {
 		}
 
 		public PSPDFDocumentInfoOption [] AvailableControllerOptions {
-			get => _AvailableControllerOptions?.Select (x => PSPDFDocumentInfoOptionExtensions.GetValue (x))?.ToArray ();
+			get => _AvailableControllerOptions?.Select (x => PSPDFDocumentInfoOptionExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFDocumentInfoOption>();
 			set => _AvailableControllerOptions = value?.Select (x => x.GetConstant ())?.ToArray ();
 		}
 	}
@@ -138,7 +138,7 @@ namespace PSPDFKit.UI {
 	public partial class PSPDFThumbnailViewController {
 
 		public PSPDFThumbnailViewFilter [] FilterOptions {
-			get => WeakFilterOptions?.Select (x => PSPDFThumbnailViewFilterExtensions.GetValue (x))?.ToArray ();
+			get => WeakFilterOptions?.Select (x => PSPDFThumbnailViewFilterExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFThumbnailViewFilter>();
 			set => WeakFilterOptions = value?.Select (x => x.GetConstant ())?.ToArray ();
 		}
 
@@ -169,7 +169,7 @@ namespace PSPDFKit.UI {
 	public partial class PSPDFDocumentSharingConfigurationBuilder {
 
 		public PSPDFActivityType [] ExcludedActivityTypes {
-			get => WeakExcludedActivityTypes?.Select (x => PSPDFActivityTypeExtensions.GetValue (x))?.ToArray ();
+			get => WeakExcludedActivityTypes?.Select (x => PSPDFActivityTypeExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFActivityType>();
 			set => WeakExcludedActivityTypes = value?.Select (x => x.GetConstant ())?.ToArray ();
 		}
 	}
@@ -177,7 +177,7 @@ namespace PSPDFKit.UI {
 	public partial class PSPDFDocumentSharingConfiguration {
 
 		public PSPDFActivityType [] ExcludedActivityTypes {
-			get => WeakExcludedActivityTypes?.Select (x => PSPDFActivityTypeExtensions.GetValue (x))?.ToArray ();
+			get => WeakExcludedActivityTypes?.Select (x => PSPDFActivityTypeExtensions.GetValue (x))?.ToArray () ?? Array.Empty<PSPDFActivityType>();
 		}
 	}
 

--- a/PSPDFKit.dotnet.iOS.UI/Enums.cs
+++ b/PSPDFKit.dotnet.iOS.UI/Enums.cs
@@ -910,18 +910,6 @@ namespace PSPDFKit.UI {
 		System,
 	}
 
-	[Flags, NoTV]
-	[Native]
-	public enum UIInterfaceOrientationMask : ulong {
-		Portrait = 1 << 1,
-		LandscapeLeft = 1 << 4,
-		LandscapeRight = 1 << 3,
-		PortraitUpsideDown = 1 << 2,
-		Landscape = LandscapeLeft | LandscapeRight,
-		All = Portrait | LandscapeLeft | LandscapeRight | PortraitUpsideDown,
-		AllButUpsideDown = Portrait | LandscapeLeft | LandscapeRight,
-	}
-
 	[Obsolete]
 	[Native]
 	public enum PSPDFContextMenuOption : long {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PSPDFKit.NET (iOS)
 
-- .NET for iOS, MacCatalyst Bindings for PSPDFKit version 13.4.0
+- .NET for iOS, MacCatalyst Bindings for PSPDFKit version 13.8.0
 
 #### PSPDFKit
 

--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Xml;
 using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
 
-var IOSVERSION = Argument("iosversion", "13.4.0");
+var IOSVERSION = Argument("iosversion", "13.8.0");
 var IOS_SERVICERELEASE_VERSION = "0"; // This is combined with the IOSVERSION variable for the NuGet Package version
 
 var target = Argument ("target", "Default");


### PR DESCRIPTION
Changes required to move to PSPDFKit for iOS 13.8.0.

Added mappings for newly introduced APIs and removed obsolete enum definition.